### PR TITLE
chore: set up a test pipeline with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: ci
+on:
+  push
+
+jobs:
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '~1.19'
+
+      - name: Tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work
 keys_saved
 keys
 bin
+
+# Editors
+.idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Quickstart
 
+[![ci](https://github.com/VANADAIN/drifter/actions/workflows/ci.yml/badge.svg)](https://github.com/VANADAIN/drifter/actions/workflows/ci.yml)
+
 # Features
 
 ### Network


### PR DESCRIPTION
Hi @VANADAIN, I've noticed that you've already set up some tests, so I thought that this repo could take advantage of that with CI using github actions.

- set up github actions
- ignore .idea folder
- add a badge of the tests pipeline in the README.md